### PR TITLE
Improve log processing performance and fix related issues

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -6,13 +6,13 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
-struct LogFile {
-    name: PathBuf,
-    parent_dir: PathBuf,
-    size: u64,
+pub(crate) struct LogFile {
+    pub(crate) name: PathBuf,
+    pub(crate) parent_dir: PathBuf,
+    pub(crate) size: u64,
 }
 
-async fn collect_log2_files(dir: impl AsRef<Path>) -> io::Result<Vec<LogFile>> {
+pub(crate) async fn collect_log2_files(dir: impl AsRef<Path>) -> io::Result<Vec<LogFile>> {
     let mut result = Vec::new();
     let mut dirs = vec![dir.as_ref().to_path_buf()];
 

--- a/src/dirtylog.rs
+++ b/src/dirtylog.rs
@@ -146,6 +146,7 @@ pub(crate) async fn dirtylog_task(
                     // Write the dirty log
                     let dirty_log_file = match tokio::fs::OpenOptions::new()
                         .write(true)
+                        .truncate(true)
                         .open(&dirty_log_path)
                         .await {
                             Ok(file) => file,

--- a/src/dirtylog.rs
+++ b/src/dirtylog.rs
@@ -1,4 +1,6 @@
-use std::path::Path;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::channel::mpsc::UnboundedReceiver;
@@ -43,6 +45,202 @@ pub(crate) async fn dirtylog_task(
 ) {
     let mut site_paths = Arc::default();
     let mut subscribers = SelectAll::<Subscriber>::default();
+
+    // Per site request
+    enum Request {
+        Get(OneshotSender<Vec<JournalEntry>>),
+        Append(JournalEntry),
+        Trim,
+    }
+
+    async fn process_request(site: String, journal_dir: PathBuf, request: Request) {
+        match request {
+            Request::Get(response_sender) => {
+                // Load the dirty log and return it in the response channel
+                let dirty_log_path =  journal_dir.join(site).join("dirtylog");
+                let res = match tokio::fs::File::open(&dirty_log_path).await {
+                    Ok(file) => {
+                        let reader = JournalReaderLog2::new(BufReader::new(file.compat())).enumerate();
+                        reader
+                            .filter_map(|(entry_no, entry_res)| {
+                                let entry = entry_res.inspect_err(|err|
+                                    warn!("Invalid journal entry no. {entry_no} in dirty log at {log_path}: {err}",
+                                        log_path = dirty_log_path.to_string_lossy()
+                                    )
+                                )
+                                    .ok();
+                                async { entry }
+                            })
+                        .collect::<Vec<_>>()
+                            .await
+                    }
+                    Err(err) => {
+                        if err.kind() != std::io::ErrorKind::NotFound {
+                            error!("Cannot open {log_path}: {err}", log_path = dirty_log_path.to_string_lossy());
+                        }
+                        Vec::new()
+                    }
+                };
+                response_sender.send(res).unwrap_or_default();
+            }
+            Request::Append(journal_entry) => {
+                let journal_site_path = journal_dir.join(site);
+                if !journal_site_path.exists() {
+                    warn!("Ignoring notification while journal directory {journal_site_path} for the site does not exist",
+                        journal_site_path = journal_site_path.to_string_lossy()
+                    );
+                    return;
+                }
+                // Append to the site's dirty log
+                let dirty_log_path = journal_site_path.join("dirtylog");
+                let dirty_log_file = match tokio::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&dirty_log_path)
+                    .await {
+                        Ok(file) => file,
+                        Err(err) => {
+                            error!("Cannot append a notification to dirty log. Cannot open file {file_path} for write: {err}",
+                                file_path = dirty_log_path.to_string_lossy()
+                            );
+                            return;
+                        }
+                    };
+                let mut writer = JournalWriterLog2::new(dirty_log_file.compat());
+                writer.append(&journal_entry)
+                    .await
+                    .unwrap_or_else(|err|
+                        error!("Cannot append a notification to dirty log {log_file}: {err}",
+                            log_file = dirty_log_path.to_string_lossy()
+                        )
+                    );
+            }
+            Request::Trim => {
+                info!("Trim dirty log start, site: {site}");
+                // Get the latest entry from the site log and remove all entries up to that
+                // entry from the dirty log
+                let dirty_log_path = journal_dir.join(&site).join("dirtylog");
+                let dirty_log_file = match tokio::fs::File::open(&dirty_log_path).await {
+                    Ok(file) => file,
+                    Err(err) => {
+                        if err.kind() == std::io::ErrorKind::NotFound {
+                            info!("Trim dirty log done, no dirty log file for the site");
+                        } else {
+                            error!("Cannot trim dirty log. Cannot open file {file_path}: {err}", file_path = dirty_log_path.to_string_lossy());
+                        }
+                        return;
+                    }
+                };
+
+                let latest_entry = {
+                    let mut log_files = match get_files(journal_dir.join(&site), is_log2_file).await {
+                        Ok(files) => files,
+                        Err(err) => {
+                            error!("Cannot trim dirty log. Cannot read journal dir entries: {err}");
+                            return;
+                        }
+                    };
+                    log_files.sort_by_key(|entry| std::cmp::Reverse(entry.file_name()));
+
+                    let latest_entry = Box::pin(futures::stream::iter(log_files)
+                        .map(|file_entry| file_entry.path())
+                        .then(|file_path|
+                            async move {
+                                match tokio::fs::File::open(&file_path).await {
+                                    Ok(file) => {
+                                        let reader = JournalReaderLog2::new(BufReader::new(file.compat()));
+                                        reader.fold(None, |_, entry| { let entry = entry.ok(); async { entry }}).await
+                                    }
+                                    Err(err) => {
+                                        error!("Cannot open file {file_path} while getting the last journal entry for trim dirtylog: {err}",
+                                            file_path = file_path.to_string_lossy()
+                                        );
+                                        None
+                                    }
+                        }
+                            })
+                        .filter_map(async move |entry| entry))
+                        .next()
+                        .await;
+
+                    match latest_entry {
+                        Some(entry) => entry,
+                        None => {
+                            info!("Trim dirty log done, no journal entries in synced files");
+                            return;
+                        }
+                    }
+                };
+
+                // Remove all entries older than the latest entry from the dirty log
+                let reader = JournalReaderLog2::new(BufReader::new(dirty_log_file.compat()));
+                let trimmed_log = reader.filter_map(|entry| {
+                    let passed_entry = entry
+                        .as_ref()
+                        .ok()
+                        .filter(|entry| entry.epoch_msec >= latest_entry.epoch_msec)
+                        .cloned();
+                    async move { passed_entry }
+                })
+                .collect::<Vec<_>>()
+                    .await;
+
+                // Write the dirty log
+                let dirty_log_file = match tokio::fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(&dirty_log_path)
+                    .await {
+                        Ok(file) => file,
+                        Err(err) => {
+                            error!("Cannot trim dirty log. Cannot open file {file_path} for write: {err}",
+                                file_path = dirty_log_path.to_string_lossy()
+                            );
+                            return;
+                        }
+                    };
+                let mut writer = JournalWriterLog2::new(dirty_log_file.compat());
+                for entry in &trimmed_log {
+                    writer.append(entry)
+                        .await
+                        .unwrap_or_else(|err|
+                            error!("Cannot write a journal entry to dirty log {log_file}: {err}",
+                                log_file = dirty_log_path.to_string_lossy()
+                            )
+                        );
+                }
+                info!("Trim dirty log done, site: {site}");
+
+            }
+        }
+    }
+
+    fn schedule_next_request<'a>(
+        site: String,
+        journal_dir: PathBuf,
+        per_site: &mut HashMap<String, VecDeque<Request>>,
+        running: &mut HashSet<String>,
+        inflight: &mut FuturesUnordered<Pin<Box<dyn futures::Future<Output = String> + Send + 'a>>>,
+    ) {
+        if running.contains(&site) {
+            return;
+        }
+        if let Some(queue) = per_site.get_mut(&site) {
+            if let Some(request) = queue.pop_front() {
+                running.insert(site.clone());
+                inflight.push(Box::pin(async move {
+                    process_request(site.clone(), journal_dir, request).await;
+                    site
+                }));
+            }
+        }
+    }
+
+    let mut site_requests: HashMap<String, VecDeque<Request>> = HashMap::new();
+    let mut site_processing: HashSet<String> = HashSet::new();
+    // Global pool of running site tasks (max 1 per site)
+    let mut inflight_requests = FuturesUnordered::new();
+
     loop {
         select! {
             command = cmd_rx.select_next_some() => match command {
@@ -74,129 +272,12 @@ pub(crate) async fn dirtylog_task(
                     );
                 }
                 DirtyLogCommand::Trim { site } => {
-                    info!("Trim dirty log start, site: {site}");
-                    // Get the latest entry from the site log and remove all entries up to that
-                    // entry from the dirty log
-                    let dirty_log_path = Path::new(&app_state.config.journal_dir).join(&site).join("dirtylog");
-                    let dirty_log_file = match tokio::fs::File::open(&dirty_log_path).await {
-                        Ok(file) => file,
-                        Err(err) => {
-                            if err.kind() == std::io::ErrorKind::NotFound {
-                                info!("Trim dirty log done, no dirty log file for the site");
-                            } else {
-                                error!("Cannot trim dirty log. Cannot open file {file_path}: {err}", file_path = dirty_log_path.to_string_lossy());
-                            }
-                            continue;
-                        }
-                    };
-
-                    let latest_entry = {
-                        let mut log_files = match get_files(&Path::new(&app_state.config.journal_dir).join(&site), is_log2_file).await {
-                            Ok(files) => files,
-                            Err(err) => {
-                                error!("Cannot trim dirty log. Cannot read journal dir entries: {err}");
-                                continue;
-                            }
-                        };
-                        log_files.sort_by_key(|entry| std::cmp::Reverse(entry.file_name()));
-
-                        let latest_entry = Box::pin(futures::stream::iter(log_files)
-                            .map(|file_entry| file_entry.path())
-                            .then(|file_path|
-                                async move {
-                                    match tokio::fs::File::open(&file_path).await {
-                                        Ok(file) => {
-                                            let reader = JournalReaderLog2::new(BufReader::new(file.compat()));
-                                            reader.fold(None, |_, entry| { let entry = entry.ok(); async { entry }}).await
-                                        }
-                                        Err(err) => {
-                                            error!("Cannot open file {file_path} while getting the last journal entry for trim dirtylog: {err}",
-                                                file_path = file_path.to_string_lossy()
-                                            );
-                                            None
-                                        }
-                                }
-                            })
-                            .filter_map(async move |entry| entry))
-                            .next()
-                            .await;
-
-                        match latest_entry {
-                            Some(entry) => entry,
-                            None => {
-                                info!("Trim dirty log done, no journal entries in synced files");
-                                continue
-                            }
-                        }
-                    };
-
-                    // Remove all entries older than the latest entry from the dirty log
-                    let reader = JournalReaderLog2::new(BufReader::new(dirty_log_file.compat()));
-                    let trimmed_log = reader.filter_map(|entry| {
-                        let passed_entry = entry
-                            .as_ref()
-                            .ok()
-                            .filter(|entry| entry.epoch_msec >= latest_entry.epoch_msec)
-                            .cloned();
-                        async move { passed_entry }
-                    })
-                    .collect::<Vec<_>>()
-                    .await;
-
-                    // Write the dirty log
-                    let dirty_log_file = match tokio::fs::OpenOptions::new()
-                        .write(true)
-                        .truncate(true)
-                        .open(&dirty_log_path)
-                        .await {
-                            Ok(file) => file,
-                            Err(err) => {
-                                error!("Cannot trim dirty log. Cannot open file {file_path} for write: {err}",
-                                    file_path = dirty_log_path.to_string_lossy()
-                                );
-                                continue;
-                            }
-                        };
-                    let mut writer = JournalWriterLog2::new(dirty_log_file.compat());
-                    for entry in &trimmed_log {
-                        writer.append(entry)
-                            .await
-                            .unwrap_or_else(|err|
-                                error!("Cannot write a journal entry to dirty log {log_file}: {err}",
-                                    log_file = dirty_log_path.to_string_lossy()
-                                )
-                            );
-                    }
-                    info!("Trim dirty log done");
-
+                    site_requests.entry(site.clone()).or_default().push_back(Request::Trim);
+                    schedule_next_request(site, Path::new(&app_state.config.journal_dir).into(), &mut site_requests, &mut site_processing, &mut inflight_requests);
                 }
                 DirtyLogCommand::Get { site, response_tx } => {
-                    // Load the dirty log and return it in the response channel
-                    let dirty_log_path =  Path::new(&app_state.config.journal_dir).join(site).join("dirtylog");
-                    let res = match tokio::fs::File::open(&dirty_log_path).await {
-                        Ok(file) => {
-                            let reader = JournalReaderLog2::new(BufReader::new(file.compat())).enumerate();
-                            reader
-                                .filter_map(|(entry_no, entry_res)| {
-                                    let entry = entry_res.inspect_err(|err|
-                                        warn!("Invalid journal entry no. {entry_no} in dirty log at {log_path}: {err}",
-                                            log_path = dirty_log_path.to_string_lossy()
-                                        )
-                                    )
-                                    .ok();
-                                    async { entry }
-                                })
-                                .collect::<Vec<_>>()
-                                .await
-                        }
-                        Err(err) => {
-                            if err.kind() != std::io::ErrorKind::NotFound {
-                                error!("Cannot open {log_path}: {err}", log_path = dirty_log_path.to_string_lossy());
-                            }
-                            Vec::new()
-                        }
-                    };
-                    response_tx.send(res).unwrap_or_default();
+                    site_requests.entry(site.clone()).or_default().push_back(Request::Get(response_tx));
+                    schedule_next_request(site, Path::new(&app_state.config.journal_dir).into(), &mut site_requests, &mut site_processing, &mut inflight_requests);
                 }
             },
             notification = subscribers.select_next_some() => {
@@ -218,33 +299,9 @@ pub(crate) async fn dirtylog_task(
                 let Some((site_path, property_path)) = find_longest_path_prefix(&*site_paths, stripped_path) else {
                     continue;
                 };
-                // If the journal_dir + site_path does not exist yet, we can ignore this notification
-                // until the directory is created during the initial sync of the site.
-                let journal_site_path = Path::new(&app_state.config.journal_dir).join(site_path);
-                if !journal_site_path.exists() {
-                    warn!("Ignoring notification while journal directory {journal_site_path} for the site does not exist",
-                        journal_site_path = journal_site_path.to_string_lossy()
-                    );
-                    continue;
-                }
-                // Append to the site's dirty log
-                let dirty_log_path = journal_site_path.join("dirtylog");
-                let dirty_log_file = match tokio::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&dirty_log_path)
-                    .await {
-                        Ok(file) => file,
-                        Err(err) => {
-                            error!("Cannot append a notification to dirty log. Cannot open file {file_path} for write: {err}",
-                                file_path = dirty_log_path.to_string_lossy()
-                            );
-                            continue;
-                        }
-                    };
-                let mut writer = JournalWriterLog2::new(dirty_log_file.compat());
+
                 let data_change = DataChange::from(param.clone());
-                let entry = JournalEntry {
+                let journal_entry = JournalEntry {
                     epoch_msec: data_change.date_time.unwrap_or_else(ShvDateTime::now).epoch_msec(),
                     path: property_path.to_string(),
                     signal,
@@ -256,14 +313,17 @@ pub(crate) async fn dirtylog_task(
                     repeat: data_change.value_flags & (1 << VALUE_FLAG_SPONTANEOUS_BIT) == 0,
                     provisional: true, // data_change.value_flags & (1 << VALUE_FLAG_PROVISIONAL_BIT) != 0,
                 };
-                writer.append(&entry)
-                    .await
-                    .unwrap_or_else(|err|
-                        error!("Cannot append a notification to dirty log {log_file}: {err}",
-                            log_file = dirty_log_path.to_string_lossy()
-                        )
-                    );
+                // Schedule next task
+                site_requests.entry(site_path.into()).or_default().push_back(Request::Append(journal_entry));
+                schedule_next_request(site_path.into(), Path::new(&app_state.config.journal_dir).into(), &mut site_requests, &mut site_processing, &mut inflight_requests);
+
+            }
+            site = inflight_requests.next() => {
+                if let Some(site) = site {
+                    site_processing.remove(&site);
+                    schedule_next_request(site, Path::new(&app_state.config.journal_dir).into(), &mut site_requests, &mut site_processing, &mut inflight_requests);
                 }
+            }
             complete => break,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ mod dirtylog;
 mod datachange;
 mod util;
 
+const MAX_JOURNAL_DIR_SIZE_DEFAULT: usize = 30 * 1_000_000_000;
+
 fn default_journal_dir() -> String {
     "/tmp/hp-rs/shvjournal".into()
 }

--- a/src/sites.rs
+++ b/src/sites.rs
@@ -287,7 +287,7 @@ pub(crate) async fn sites_task(
                 },
                 None => break,
             },
-            mntchng_frame = mntchng_subscribers.select_next_some() => {
+            mntchng_frame = mntchng_subscribers.select_next_some(), if !mntchng_subscribers.is_empty() => {
                 let msg = match mntchng_frame.to_rpcmesage() {
                     Ok(msg) => msg,
                     Err(err) => {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -783,8 +783,10 @@ pub(crate) async fn sync_task(
                             panic!("Cannot send dirtylog Trim command for site {site}: {e}")
                         )
                     );
-
-                app_state.sync_cmd_tx.unbounded_send(SyncCommand::Cleanup).unwrap_or_default();
+                match cleanup_log2_files(&app_state.config.journal_dir, max_journal_dir_size).await {
+                    Ok(_) => info!("Cleanup journal dir done"),
+                    Err(err) => error!("Cleanup journal dir error: {err}"),
+                }
             }
             SyncCommand::SyncSite(site) => {
                 let files_to_download = get_files_to_sync(
@@ -846,7 +848,10 @@ pub(crate) async fn sync_task(
                         .unwrap_or_else(|e|
                             panic!("Cannot send dirtylog Trim command for site {site}: {e}")
                         );
-                    app_state.sync_cmd_tx.unbounded_send(SyncCommand::Cleanup).unwrap_or_default();
+                    match cleanup_log2_files(&app_state.config.journal_dir, max_journal_dir_size).await {
+                        Ok(_) => info!("Cleanup journal dir done"),
+                        Err(err) => error!("Cleanup journal dir error: {err}"),
+                    }
                 } else {
                     warn!("Requested sync for unknown site: {site}");
                 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -25,7 +25,7 @@ use crate::journalrw::{GetLog2Params, GetLog2Since, JournalReaderLog2, JournalWr
 use crate::sites::{SitesData, SubHpInfo};
 use crate::tree::{FileType, LsFilesEntry, METH_READ};
 use crate::util::{get_files, is_log2_file};
-use crate::{ClientCommandSender, State};
+use crate::{ClientCommandSender, State, MAX_JOURNAL_DIR_SIZE_DEFAULT};
 
 #[derive(Default)]
 pub(crate) struct SyncInfo {
@@ -666,7 +666,6 @@ async fn sync_site_legacy(
 }
 
 const MAX_SYNC_TASKS_DEFAULT: usize = 8;
-const MAX_JOURNAL_DIR_SIZE_DEFAULT: usize = 30 * 1_000_000_000;
 
 pub(crate) async fn sync_task(
     client_cmd_tx: ClientCommandSender,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -182,13 +182,8 @@ async fn get_files_to_sync(
                         .unwrap_or_default();
                     remote_files
                         .into_iter()
-                        .filter(|entry| matches!(entry.ftype, FileType::File))
-                        .filter_map(|entry| entry
-                            .name
-                            .strip_suffix(".log2")
-                            .and_then(|file| shvproto::DateTime::from_iso_str(file).ok().as_ref().map(shvproto::DateTime::epoch_msec))
-                            .map(|_| (site_path, entry))
-                        )
+                        .filter(|entry| matches!(entry.ftype, FileType::File) && entry.name.ends_with(".log2"))
+                        .map(|entry| (site_path, entry))
                         .collect::<Vec<_>>()
                 })
             } else {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -864,13 +864,14 @@ async fn getlog_impl(
             }
     };
 
+    let record_count = snapshot_entries.len() as i64 + context.entries.len() as i64;
     let (mut result, paths_dict) = journal_entries_to_rpcvalue(
         snapshot_entries.iter().chain(context.entries.iter().map(|arc_entry| arc_entry.as_ref())),
         params.with_paths_dict
     );
 
     result.meta = Some(Box::new(Log2Header {
-        record_count: context.record_count as _,
+        record_count,
         record_count_limit: context.record_count_limit as _,
         record_count_limit_hit: context.record_count_limit_hit,
         date_time: current_datetime,


### PR DESCRIPTION
This PR introduces a series of improvements and fixes to dirtylog and `getLog` handling, aiming to enhance performance, reduce blocking, and ensure correct log boundaries.

**Key changes:**

 - Parallelized dirtylog commands across sites (serial per site) to prevent blocking from long-running Trim operations.

 - Created dirtylog automatically when a journal site directory exists.

 - Stopped getlog processing once the record count limit is reached to preserve correct until values.

 - Fixed `record_count` to include snapshot entries.

 - Invoked `cleanup_log2_files` immediately after sync to avoid delays caused by queued cleanup requests.

 - Added remote file exclusion info in `get_files_to_sync` output.

 - Fixed remote file filtering in `get_files_to_sync`.

 - Ensured `select_next_some` is only called when `mntchng_subscribers` is non-empty.

 - Implemented log size management methods: `logSizeLimit`, `totalLogSize`, and `logUsage`.

 - Truncated dirtylog file in Trim implementation.

**Impact:**

 - Reduced latency for Get commands invoked by getLog handler.

 - Improved accuracy of log processing limits.

 - Increased robustness in file syncing and log size handling.