### PR TITLE
sync: Reject larger data chunks than requested

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -437,11 +437,15 @@ async fn sync_file(
             .await
             .map_err(to_string)?;
 
+        let chunk_len = chunk.len() as i64;
+        if chunk_len > sync_size {
+            return Err(format!("{file_path_remote}: Got chunk of size: {chunk_len}, which is larger than requested: {sync_size}"));
+        }
+
         local_file.write_all(&chunk)
           .await
           .map_err(|e| format!("Cannot write to {}: {e}", file_path_local.to_string_lossy()))?;
 
-        let chunk_len = chunk.len() as i64;
         sync_offset += chunk_len;
         remaining_bytes -= chunk_len;
 


### PR DESCRIPTION
If a sync download request expects data of a specific size and the response includes more data, it should be rejected with an error.