### PR TITLE
Limit maximum dirty log size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "historyprovider"
-version = "2.12.2"
+version = "2.13.0"
 dependencies = [
  "async-broadcast",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "historyprovider"
 description = "historyprovider-rs"
 license = "MIT"
 repository = "https://github.com/silicon-heaven/historyprovider-rs"
-version = "2.12.2"
+version = "2.13.0"
 edition = "2024"
 
 [profile.release]

--- a/src/dirtylog.rs
+++ b/src/dirtylog.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use futures::channel::mpsc::UnboundedReceiver;
 use futures::channel::oneshot::Sender as OneshotSender;
@@ -100,6 +100,25 @@ pub(crate) async fn dirtylog_task(
                             return;
                         }
                     };
+                if let Ok(metadata) = dirty_log_file.metadata().await {
+                    let size = metadata.len();
+
+                    static DIRTY_LOG_SIZE_MAX: OnceLock<u64> = OnceLock::new();
+                    let max_size = *DIRTY_LOG_SIZE_MAX.get_or_init(|| {
+                        std::env::var("DIRTY_LOG_SIZE_MAX")
+                            .ok()
+                            .and_then(|val| val.parse::<u64>().ok())
+                            .unwrap_or(100 * 1024 * 1024)
+                    });
+
+                    if size > max_size {
+                        log::trace!(
+                            "Dirty log {path} max size exceeded ({size} > {max_size}), dropping journal entry {journal_entry:?}",
+                            path = dirty_log_path.display()
+                        );
+                        return;
+                    }
+                }
                 let mut writer = JournalWriterLog2::new(dirty_log_file.compat());
                 writer.append(&journal_entry)
                     .await


### PR DESCRIPTION
Limit dirty log growth when files synchronization fails to prevent unbounded memory consumption.