### PR TITLE
Fix-up non-monotonic timestamps of getLog result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "historyprovider"
-version = "2.13.7"
+version = "3.0.0"
 dependencies = [
  "async-broadcast",
  "async-compression",
@@ -1649,9 +1649,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shvclient"
-version = "6.0.2"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2095b574cb56ae25cfc7dd37e798a0a912e24c3c7d02ff82326f383c922aa25e"
+checksum = "d58f26899d416ace2ae6b1a71462d77bf9fb257c4e7786c47d3629fa7aad787c"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -1688,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "shvrpc"
-version = "16.1.2"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be81e1063dad375062d49f5e7501bb0fbadf156f2b0924486e7e2b26da551717"
+checksum = "af43d81a86ec9956d2adb905843245d51b813147ded1c6aed73d12a43dc1e325"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "historyprovider"
 description = "historyprovider-rs"
 license = "MIT"
 repository = "https://github.com/silicon-heaven/historyprovider-rs"
-version = "2.13.7"
+version = "3.0.0"
 edition = "2024"
 
 [profile.release]
@@ -18,8 +18,8 @@ name = "hp"
 [dependencies]
 tokio = { version = "1.52.3", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"], default-features = false }
 shvproto = "6.2.0"
-shvrpc = { version = "16.1", features = ["journal"] }
-shvclient = { version = "6.0", features = ["tokio"] }
+shvrpc = { version = "17.0", features = ["journal"] }
+shvclient = { version = "7.0", features = ["tokio"] }
 futures = "0.3.32"
 log = "0.4.32"
 clap = { version = "4.6.0", features = ["derive"] }
@@ -48,5 +48,5 @@ size = { version = "0.5.0", features = ["serde"] }
 [dev-dependencies]
 async-broadcast = "0.7.2"
 async-trait = "0.1.80"
-shvclient = { version = "6.0", features = ["mocking", "tokio"] }
+shvclient = { version = "7.0", features = ["mocking", "tokio"] }
 tempfile = "3.27.0"

--- a/src/dirtylog.rs
+++ b/src/dirtylog.rs
@@ -305,6 +305,7 @@ pub(crate) async fn dirtylog_task(
                     let data_change = DataChange::from(param);
                     let journal_entry = JournalEntry {
                         epoch_msec: data_change.date_time.unwrap_or_else(ShvDateTime::now).epoch_msec(),
+                        epoch_msec_orig: None,
                         path: property_path,
                         signal,
                         source,
@@ -476,6 +477,7 @@ mod tests {
                         site: "site1".to_string(),
                         expected: vec![JournalEntry {
                             epoch_msec: 1657152000000,
+                            epoch_msec_orig: None,
                             path: "some_value_node".into(),
                             signal: "chng".into(),
                             source: "get".into(),
@@ -500,6 +502,7 @@ mod tests {
                         site: "site1".to_string(),
                         expected: vec![JournalEntry {
                             epoch_msec: 1657152000000,
+                            epoch_msec_orig: None,
                             path: "some_value_node".into(),
                             signal: "chng".into(),
                             source: "get".into(),

--- a/src/getlog.rs
+++ b/src/getlog.rs
@@ -255,7 +255,12 @@ pub(crate) async fn getlog_impl(
     'outer: for mut reader in journal_readers {
         while let Some(entry_res) = reader.next().await {
             match entry_res {
-                Ok(entry) => {
+                Ok(mut entry) => {
+                    // Fixup non-monotonic timestamps to the timestamp of the last monotonic entry
+                    if let Some(last_entry) = context.last_entry.as_ref() && entry.epoch_msec < last_entry.epoch_msec {
+                        entry.epoch_msec_orig = Some(entry.epoch_msec);
+                        entry.epoch_msec = last_entry.epoch_msec;
+                    }
                     if !process_journal_entry(entry, &mut context) {
                         break 'outer;
                     }
@@ -268,10 +273,17 @@ pub(crate) async fn getlog_impl(
     // Only append entries from the dirtylog if they are adjacent to the journal entries or else
     // the resulting `until` will be incorrectly taken from the first dirtylog entry.
     if !context.record_count_limit_hit {
-        for entry in dirty_log {
+        let synced_files_last_entry = context.last_entry.clone();
+        for mut entry in dirty_log {
             // Filter out entries that overlap with the entries from the synced files
-            if context.last_entry.as_ref().is_some_and(|last_entry| entry.epoch_msec < last_entry.epoch_msec) {
+            if synced_files_last_entry.as_ref().is_some_and(|last_entry| entry.epoch_msec < last_entry.epoch_msec) {
                 continue;
+            }
+
+            // Fixup non-monotonic timestamps to the timestamp of the last monotonic entry
+            if let Some(last_entry) = context.last_entry.as_ref() && entry.epoch_msec < last_entry.epoch_msec {
+                entry.epoch_msec_orig = Some(entry.epoch_msec);
+                entry.epoch_msec = last_entry.epoch_msec;
             }
 
             if !process_journal_entry(entry, &mut context) {
@@ -380,6 +392,7 @@ mod tests {
         Ok(JournalEntry {
             path: path.to_string(),
             epoch_msec: DateTime::from_iso_str(timestamp).unwrap().epoch_msec(),
+            epoch_msec_orig: None,
             signal: "chng".to_string(),
             short_time: -1,
             access_level: 32,
@@ -397,6 +410,78 @@ mod tests {
 
     async fn get_log_entries(site: &str, readers: Vec<JournalEntryStream>, params: GetLog2Params) -> GetLogResult {
         getlog_impl(site, readers, [], &params).await
+    }
+
+    #[tokio::test]
+    async fn dirtylog_non_monotonic_timestamps_are_fixed_up() {
+        let fixed_msec = ts("2022-07-07T18:06:11.000Z").epoch_msec();
+        let original_msec = ts("2022-07-07T18:06:10.500Z").epoch_msec();
+
+        let result = getlog_impl(
+            "test",
+            vec![create_reader(vec![
+                make_entry("2022-07-07T18:06:10.000Z", "synced", 1),
+            ])],
+            vec![
+                make_entry("2022-07-07T18:06:09.000Z", "overlap", 2).unwrap(),
+                make_entry("2022-07-07T18:06:11.000Z", "dirty_monotonic", 3).unwrap(),
+                make_entry("2022-07-07T18:06:10.500Z", "dirty_non_monotonic", 4).unwrap(),
+                make_entry("2022-07-07T18:06:12.000Z", "dirty_later", 5).unwrap(),
+            ],
+            &Default::default(),
+        ).await;
+
+        assert_eq!(result.snapshot_entries.len(), 1);
+        assert_eq!(result.snapshot_entries[0].path, "synced");
+
+        let event_entries = result.event_entries;
+        assert_eq!(event_entries.len(), 3);
+        assert_eq!(event_entries[0].path, "dirty_monotonic");
+        assert_eq!(event_entries[0].epoch_msec, fixed_msec);
+        assert_eq!(event_entries[0].epoch_msec_orig, None);
+        assert_eq!(event_entries[1].path, "dirty_non_monotonic");
+        assert_eq!(event_entries[1].epoch_msec, fixed_msec);
+        assert_eq!(event_entries[1].epoch_msec_orig, Some(original_msec));
+        assert_eq!(event_entries[2].path, "dirty_later");
+        assert_eq!(event_entries[2].epoch_msec, ts("2022-07-07T18:06:12.000Z").epoch_msec());
+        assert_eq!(event_entries[2].epoch_msec_orig, None);
+    }
+
+    #[tokio::test]
+    async fn journal_readers_non_monotonic_timestamps_are_fixed_up() {
+        let fixed_msec = ts("2022-07-07T18:06:11.000Z").epoch_msec();
+        let original_msec = ts("2022-07-07T18:06:10.500Z").epoch_msec();
+
+        let result = getlog_impl(
+            "test",
+            vec![
+                create_reader(vec![
+                    make_entry("2022-07-07T18:06:10.000Z", "synced_snapshot", 1),
+                    make_entry("2022-07-07T18:06:11.000Z", "synced_monotonic", 2),
+                ]),
+                create_reader(vec![
+                    make_entry("2022-07-07T18:06:10.500Z", "synced_non_monotonic", 3),
+                    make_entry("2022-07-07T18:06:12.000Z", "synced_later", 4),
+                ]),
+            ],
+            [],
+            &Default::default(),
+        ).await;
+
+        assert_eq!(result.snapshot_entries.len(), 1);
+        assert_eq!(result.snapshot_entries[0].path, "synced_snapshot");
+
+        let event_entries = result.event_entries;
+        assert_eq!(event_entries.len(), 3);
+        assert_eq!(event_entries[0].path, "synced_monotonic");
+        assert_eq!(event_entries[0].epoch_msec, fixed_msec);
+        assert_eq!(event_entries[0].epoch_msec_orig, None);
+        assert_eq!(event_entries[1].path, "synced_non_monotonic");
+        assert_eq!(event_entries[1].epoch_msec, fixed_msec);
+        assert_eq!(event_entries[1].epoch_msec_orig, Some(original_msec));
+        assert_eq!(event_entries[2].path, "synced_later");
+        assert_eq!(event_entries[2].epoch_msec, ts("2022-07-07T18:06:12.000Z").epoch_msec());
+        assert_eq!(event_entries[2].epoch_msec_orig, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
getLog implementation will return all entries with timestamps fixed up to the last monotonic value.