### PR TITLE
Implement log3 records timestamp adjustment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "historyprovider"
-version = "3.1.6"
+version = "3.1.7"
 dependencies = [
  "async-broadcast",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "historyprovider"
 description = "historyprovider-rs"
 license = "MIT"
 repository = "https://github.com/silicon-heaven/historyprovider-rs"
-version = "3.1.6"
+version = "3.1.7"
 edition = "2024"
 
 [profile.release]

--- a/src/record.rs
+++ b/src/record.rs
@@ -29,6 +29,8 @@ pub struct LogEntry {
     pub access_level: i64,  // default: Read
     pub user_id: Option<String>,
     pub repeat: bool,       // default: false
+    pub adjusted_timestamp: Option<i64>,
+    pub provisional: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -180,6 +182,8 @@ pub(crate) fn log_records_from_fetch(start_offset: i64, srcs: &[IMap]) -> shvrpc
                         repeat: get_field_checked(src, LogField::Repeat)
                             .map_err(|e| record_err(&format!("wrong `repeat` type: {e}")))?
                             .unwrap_or_default(),
+                        adjusted_timestamp: None,
+                        provisional: false,
                     };
                     if type_id == 1 {
                         RecordType::Normal(entry)

--- a/src/records.rs
+++ b/src/records.rs
@@ -34,19 +34,20 @@ pub(crate) async fn ensure_db(path: impl AsRef<Path>) -> Result<SqliteConnection
     }
     let mut conn = open_db(path).await?;
     sqlx::query(
-        "CREATE TABLE IF NOT EXISTS journal_entries (
-            id INTEGER PRIMARY KEY,
-            type INTEGER NOT NULL,
-            epoch_msec INTEGER NOT NULL,
-            path TEXT,
-            signal TEXT,
-            source TEXT,
-            value TEXT,
-            access_level INTEGER,
-            user_id TEXT,
-            repeat INTEGER,
-            time_jump INTEGER
-        )",
+            "CREATE TABLE IF NOT EXISTS journal_entries (
+                id INTEGER PRIMARY KEY,
+                type INTEGER NOT NULL,
+                epoch_msec INTEGER NOT NULL,
+                path TEXT,
+                signal TEXT,
+                source TEXT,
+                value TEXT,
+                access_level INTEGER,
+                user_id TEXT,
+                repeat INTEGER,
+                time_jump INTEGER,
+                provisional INTEGER NOT NULL DEFAULT 0
+            )",
     )
     .execute(&mut conn)
     .await
@@ -90,7 +91,7 @@ pub(crate) async fn span_records(path: impl AsRef<Path>) -> Result<(i64, i64, i6
     Ok((smallest, biggest, 1))
 }
 
-type LogRecordRow = (i64, i64, Option<String>, Option<String>, Option<String>, Option<String>, Option<i64>, Option<String>, Option<i64>, Option<i64>);
+type LogRecordRow = (i64, i64, Option<String>, Option<String>, Option<String>, Option<String>, Option<i64>, Option<String>, Option<i64>, Option<i64>, Option<i64>);
 
 fn record_to_values(record: &LogRecord) -> LogRecordRow {
     let mut path = None;
@@ -101,6 +102,7 @@ fn record_to_values(record: &LogRecord) -> LogRecordRow {
     let mut user_id = None;
     let mut repeat = None;
     let mut time_jump = None;
+    let mut provisional = None;
 
     match &record.record_type {
         RecordType::Normal(entry) | RecordType::Keep(entry) => {
@@ -123,6 +125,7 @@ fn record_to_values(record: &LogRecord) -> LogRecordRow {
             if entry.repeat {
                 repeat = Some(1);
             }
+            provisional = Some(i64::from(entry.provisional));
         }
         RecordType::TimeJump(offset) => {
             time_jump = Some(*offset);
@@ -130,18 +133,18 @@ fn record_to_values(record: &LogRecord) -> LogRecordRow {
         RecordType::TimeAmbig => {}
     }
 
-    (record.record_type.type_id(), record.timestamp.epoch_msec(), path, signal, source, value, access_level, user_id, repeat, time_jump)
+    (record.record_type.type_id(), record.timestamp.epoch_msec(), path, signal, source, value, access_level, user_id, repeat, time_jump, provisional)
 }
 
 pub(crate) async fn insert_records(path: impl AsRef<Path>, records: &[LogRecord]) -> Result<(), String> {
     let mut conn = ensure_db(path).await?;
 
     for record in records {
-        let (type_id, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump) = record_to_values(record);
+        let (type_id, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump, provisional) = record_to_values(record);
         sqlx::query(
             "INSERT OR IGNORE INTO journal_entries (
-                id, type, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                id, type, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump, provisional
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         .bind(record.id)
         .bind(type_id)
@@ -154,6 +157,7 @@ pub(crate) async fn insert_records(path: impl AsRef<Path>, records: &[LogRecord]
         .bind(&user_id)
         .bind(repeat)
         .bind(time_jump)
+        .bind(provisional)
         .execute(&mut conn)
         .await
         .map_err(|e| e.to_string())?;
@@ -181,10 +185,11 @@ fn row_to_record(row: &SqliteRow) -> Result<LogRecord, String> {
     let user_id = row.try_get::<Option<String>, _>(8).map_err(|e| e.to_string())?;
     let repeat = row.try_get::<Option<i64>, _>(9).map_err(|e| e.to_string())?.is_some_and(|repeat| repeat != 0);
     let time_jump = row.try_get::<Option<i64>, _>(10).map_err(|e| e.to_string())?;
+    let provisional = row.try_get::<Option<i64>, _>(11).map_err(|e| e.to_string())?.unwrap_or_default() != 0;
 
     let record_type = match type_id {
-        1 => RecordType::Normal(LogEntry { path, signal, source, value, access_level, user_id, repeat }),
-        2 => RecordType::Keep(LogEntry { path, signal, source, value, access_level, user_id, repeat }),
+        1 => RecordType::Normal(LogEntry { path, signal, source, value, access_level, user_id, repeat, adjusted_timestamp: None, provisional }),
+        2 => RecordType::Keep(LogEntry { path, signal, source, value, access_level, user_id, repeat, adjusted_timestamp: None, provisional }),
         3 => RecordType::TimeJump(time_jump.ok_or_else(|| format!("Missing time jump offset for record id {id}"))?),
         4 => RecordType::TimeAmbig,
         _ => return Err(format!("Wrong stored record type {type_id} for id {id}")),
@@ -204,7 +209,7 @@ pub(crate) async fn fetch_records(path: impl AsRef<Path>, offset: i64, count: i6
 
     let mut conn = open_db(path).await?;
     let rows = sqlx::query(
-        "SELECT id, type, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump
+        "SELECT id, type, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump, provisional
         FROM journal_entries
         WHERE id >= ? AND id < ?
         ORDER BY id
@@ -246,7 +251,7 @@ async fn query_log_records(
         format!("{path_prefix}/%")
     };
     let query = format!(
-        "SELECT id, type, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump
+        "SELECT id, type, epoch_msec, path, signal, source, value, access_level, user_id, repeat, time_jump, provisional
         FROM journal_entries
         WHERE epoch_msec {from_op} ? AND epoch_msec {to_op} ? AND (? = '' OR path = ? OR path LIKE ?)
         ORDER BY epoch_msec {order}, id {order}"
@@ -275,6 +280,55 @@ fn relative_path<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
         return Some("");
     }
     path.strip_prefix(prefix)?.strip_prefix('/')
+}
+
+fn adjust_entry_timestamp(record: &mut LogRecord, adjust: impl Fn(i64) -> i64) {
+    if let RecordType::Normal(entry) | RecordType::Keep(entry) = &mut record.record_type
+        && !entry.provisional
+    {
+        entry.adjusted_timestamp = Some(adjust(record.timestamp.epoch_msec()));
+    }
+}
+
+#[expect(clippy::indexing_slicing, reason = "All accesses guarded by prior emptiness checks and windows(2)")]
+pub(crate) fn adjust_timestamps(records: &mut [LogRecord]) {
+    let tj_indices: Vec<usize> = records.iter()
+        .enumerate()
+        .filter(|(_, r)| matches!(r.record_type, RecordType::TimeJump(_)))
+        .map(|(i, _)| i)
+        .collect();
+
+    if tj_indices.is_empty() {
+        return;
+    }
+
+    let first_tj_idx = tj_indices[0];
+    let first_offset = match &records[first_tj_idx].record_type {
+        RecordType::TimeJump(offset) => *offset,
+        _ => unreachable!(),
+    };
+
+    for record in records.iter_mut().take(first_tj_idx) {
+        adjust_entry_timestamp(record, |ti| ti + first_offset);
+    }
+
+    for pair in tj_indices.windows(2) {
+        let i_a = pair[0];
+        let i_b = pair[1];
+        let ts_a = records[i_a].timestamp.epoch_msec();
+        let ts_b = records[i_b].timestamp.epoch_msec();
+        let offset_b = match &records[i_b].record_type {
+            RecordType::TimeJump(o) => *o,
+            _ => unreachable!(),
+        };
+        let denom = ts_b - offset_b - ts_a;
+        if denom <= 0 {
+            continue;
+        }
+        for record in records.iter_mut().take(i_b).skip(i_a + 1) {
+            adjust_entry_timestamp(record, |ti| ti + offset_b * (ti - ts_a) / denom);
+        }
+    }
 }
 
 fn getlog_record_to_imap(record: LogRecord, path_prefix: &str, path_pattern: Option<&ShvRI>) -> Option<(i64, IMap)> {
@@ -307,7 +361,8 @@ fn getlog_record_to_imap(record: LogRecord, path_prefix: &str, path_pattern: Opt
     if entry.repeat {
         map.insert(8, true.into());
     }
-    Some((timestamp.epoch_msec(), map))
+    let result_ts = entry.adjusted_timestamp.unwrap_or_else(|| timestamp.epoch_msec());
+    Some((result_ts, map))
 }
 
 #[expect(clippy::too_many_arguments, reason = "This is AI slop")]
@@ -325,9 +380,10 @@ pub(crate) async fn getlog_records(
     let mut records = Vec::new();
     for record_name in record_names {
         let db_path = db_path(journal_dir.as_ref(), site_path, record_name);
+        let mut log_records = query_log_records(db_path, since, until, path_prefix).await?;
+        adjust_timestamps(&mut log_records);
         records.extend(
-            query_log_records(db_path, since, until, path_prefix)
-                .await?
+            log_records
                 .into_iter()
                 .filter_map(|record| getlog_record_to_imap(record, path_prefix, path_pattern))
         );
@@ -418,6 +474,8 @@ mod tests {
                 access_level: AccessLevel::Read as i64,
                 user_id: None,
                 repeat: false,
+                adjusted_timestamp: None,
+                provisional: false,
             }),
         }
     }

--- a/src/records.rs
+++ b/src/records.rs
@@ -58,6 +58,15 @@ pub(crate) async fn ensure_db(path: impl AsRef<Path>) -> Result<SqliteConnection
     .execute(&mut conn)
     .await
     .map_err(|e| e.to_string())?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS time_drift (
+            offset INTEGER NOT NULL,
+            epoch_msec INTEGER NOT NULL
+        )",
+    )
+    .execute(&mut conn)
+    .await
+    .map_err(|e| e.to_string())?;
     Ok(conn)
 }
 
@@ -164,6 +173,40 @@ pub(crate) async fn insert_records(path: impl AsRef<Path>, records: &[LogRecord]
     }
 
     Ok(())
+}
+
+pub(crate) async fn set_time_drift(path: impl AsRef<Path>, offset: i64, epoch_msec: i64) -> Result<(), String> {
+    let mut conn = ensure_db(path).await?;
+    let mut tx = conn.begin().await.map_err(|e| e.to_string())?;
+    sqlx::query("DELETE FROM time_drift")
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    sqlx::query("INSERT INTO time_drift (offset, epoch_msec) VALUES (?, ?)")
+        .bind(offset)
+        .bind(epoch_msec)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    tx.commit().await.map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+pub(crate) async fn get_time_drift(path: impl AsRef<Path>) -> Result<Option<(i64, i64)>, String> {
+    if tokio::fs::metadata(path.as_ref()).await.is_err() {
+        return Ok(None);
+    }
+    let mut conn = open_db(path).await?;
+    let row = sqlx::query("SELECT offset, epoch_msec FROM time_drift LIMIT 1")
+        .fetch_optional(&mut conn)
+        .await
+        .map_err(|e| e.to_string())?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let offset = row.try_get::<i64, _>(0).map_err(|e| e.to_string())?;
+    let epoch_msec = row.try_get::<i64, _>(1).map_err(|e| e.to_string())?;
+    Ok(Some((offset, epoch_msec)))
 }
 
 fn parse_value(value: Option<String>, id: i64) -> Result<Option<RpcValue>, String> {
@@ -380,7 +423,14 @@ pub(crate) async fn getlog_records(
     let mut records = Vec::new();
     for record_name in record_names {
         let db_path = db_path(journal_dir.as_ref(), site_path, record_name);
-        let mut log_records = query_log_records(db_path, since, until, path_prefix).await?;
+        let mut log_records = query_log_records(&db_path, since, until, path_prefix).await?;
+        if let Some((time_jump, epoch_msec)) = get_time_drift(&db_path).await? {
+            log_records.push(LogRecord {
+                id: 0,
+                timestamp: shvproto::DateTime::from_epoch_msec(epoch_msec),
+                record_type: RecordType::TimeJump(time_jump),
+            });
+        }
         adjust_timestamps(&mut log_records);
         records.extend(
             log_records
@@ -529,5 +579,48 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(String::try_from(result[0].get(&3).unwrap()).unwrap(), "a");
         assert_eq!(String::try_from(result[1].get(&3).unwrap()).unwrap(), "b");
+    }
+
+    #[tokio::test]
+    async fn time_drift_roundtrip() {
+        let journal_dir = tempfile::TempDir::with_prefix("test-hprs-records-getlog.").unwrap();
+        let journal_dir = journal_dir.path().to_str().unwrap();
+        let db_path = db_path(journal_dir, "site1", "maintenance");
+        assert_eq!(get_time_drift(&db_path).await.unwrap(), None);
+        set_time_drift(&db_path, 3_600_000, 1_700_000_000_000).await.unwrap();
+        assert_eq!(get_time_drift(&db_path).await.unwrap(), Some((3_600_000, 1_700_000_000_000)));
+        set_time_drift(&db_path, -1_000, 1_700_000_360_000).await.unwrap();
+        assert_eq!(get_time_drift(&db_path).await.unwrap(), Some((-1_000, 1_700_000_360_000)));
+    }
+
+    #[tokio::test]
+    async fn getlog_records_applies_time_drift() {
+        let journal_dir = tempfile::TempDir::with_prefix("test-hprs-records-getlog.").unwrap();
+        let journal_dir = journal_dir.path().to_str().unwrap();
+        let db_path = db_path(journal_dir, "site1", "maintenance");
+        insert_records(&db_path, &[
+            record(0, 1000, "some/a", 1),
+            record(1, 2000, "some/b", 2),
+        ]).await.unwrap();
+        set_time_drift(&db_path, 3_600_000, 1_700_000_000_000).await.unwrap();
+
+        let mut log_records = query_log_records(
+            &db_path,
+            shvproto::DateTime::from_epoch_msec(0),
+            shvproto::DateTime::from_epoch_msec(3000),
+            "",
+        ).await.unwrap();
+        let (time_jump, epoch_msec) = get_time_drift(&db_path).await.unwrap().unwrap();
+        log_records.push(LogRecord {
+            id: 0,
+            timestamp: shvproto::DateTime::from_epoch_msec(epoch_msec),
+            record_type: RecordType::TimeJump(time_jump),
+        });
+        adjust_timestamps(&mut log_records);
+        for record in log_records {
+            if let RecordType::Normal(entry) = record.record_type {
+                assert_eq!(entry.adjusted_timestamp, Some(record.timestamp.epoch_msec() + 3_600_000));
+            }
+        }
     }
 }

--- a/src/records.rs
+++ b/src/records.rs
@@ -17,6 +17,12 @@ pub(crate) fn db_path(journal_dir: impl AsRef<str>, site_path: impl AsRef<str>, 
         .join(format!("{}.db", record_name.as_ref()))
 }
 
+pub(crate) fn site_db_path(journal_dir: impl AsRef<str>, site_path: impl AsRef<str>) -> PathBuf {
+    Path::new(journal_dir.as_ref())
+        .join(site_path.as_ref())
+        .join("time_drift.db")
+}
+
 async fn open_db(path: impl AsRef<Path>) -> Result<SqliteConnection, String> {
     let options = SqliteConnectOptions::new()
         .filename(path.as_ref())
@@ -26,13 +32,17 @@ async fn open_db(path: impl AsRef<Path>) -> Result<SqliteConnection, String> {
         .map_err(|e| e.to_string())
 }
 
-pub(crate) async fn ensure_db(path: impl AsRef<Path>) -> Result<SqliteConnection, String> {
+async fn open_db_with_dirs(path: impl AsRef<Path>) -> Result<SqliteConnection, String> {
     if let Some(parent) = path.as_ref().parent() {
         tokio::fs::create_dir_all(parent)
             .await
             .map_err(|err| format!("Cannot create records DB directory {}: {err}", parent.to_string_lossy()))?;
     }
-    let mut conn = open_db(path).await?;
+    open_db(path).await
+}
+
+pub(crate) async fn ensure_db(path: impl AsRef<Path>) -> Result<SqliteConnection, String> {
+    let mut conn = open_db_with_dirs(path).await?;
     sqlx::query(
             "CREATE TABLE IF NOT EXISTS journal_entries (
                 id INTEGER PRIMARY KEY,
@@ -58,6 +68,11 @@ pub(crate) async fn ensure_db(path: impl AsRef<Path>) -> Result<SqliteConnection
     .execute(&mut conn)
     .await
     .map_err(|e| e.to_string())?;
+    Ok(conn)
+}
+
+pub(crate) async fn ensure_site_db(path: impl AsRef<Path>) -> Result<SqliteConnection, String> {
+    let mut conn = open_db_with_dirs(path).await?;
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS time_drift (
             offset INTEGER NOT NULL,
@@ -176,7 +191,7 @@ pub(crate) async fn insert_records(path: impl AsRef<Path>, records: &[LogRecord]
 }
 
 pub(crate) async fn set_time_drift(path: impl AsRef<Path>, offset: i64, epoch_msec: i64) -> Result<(), String> {
-    let mut conn = ensure_db(path).await?;
+    let mut conn = ensure_site_db(path).await?;
     let mut tx = conn.begin().await.map_err(|e| e.to_string())?;
     sqlx::query("DELETE FROM time_drift")
         .execute(&mut *tx)
@@ -420,11 +435,12 @@ pub(crate) async fn getlog_records(
     path_pattern: Option<&ShvRI>,
 ) -> Result<Vec<IMap>, String> {
     let reverse = until.epoch_msec() < since.epoch_msec();
+    let time_drift = get_time_drift(site_db_path(journal_dir.as_ref(), site_path)).await?;
     let mut records = Vec::new();
     for record_name in record_names {
         let db_path = db_path(journal_dir.as_ref(), site_path, record_name);
         let mut log_records = query_log_records(&db_path, since, until, path_prefix).await?;
-        if let Some((time_jump, epoch_msec)) = get_time_drift(&db_path).await? {
+        if let Some((time_jump, epoch_msec)) = time_drift {
             log_records.push(LogRecord {
                 id: 0,
                 timestamp: shvproto::DateTime::from_epoch_msec(epoch_msec),
@@ -702,12 +718,12 @@ mod tests {
     async fn time_drift_roundtrip() {
         let journal_dir = tempfile::TempDir::with_prefix("test-hprs-records-getlog.").unwrap();
         let journal_dir = journal_dir.path().to_str().unwrap();
-        let db_path = db_path(journal_dir, "site1", "maintenance");
-        assert_eq!(get_time_drift(&db_path).await.unwrap(), None);
-        set_time_drift(&db_path, 3_600_000, 1_700_000_000_000).await.unwrap();
-        assert_eq!(get_time_drift(&db_path).await.unwrap(), Some((3_600_000, 1_700_000_000_000)));
-        set_time_drift(&db_path, -1_000, 1_700_000_360_000).await.unwrap();
-        assert_eq!(get_time_drift(&db_path).await.unwrap(), Some((-1_000, 1_700_000_360_000)));
+        let time_drift_db = site_db_path(journal_dir, "site1");
+        assert_eq!(get_time_drift(&time_drift_db).await.unwrap(), None);
+        set_time_drift(&time_drift_db, 3_600_000, 1_700_000_000_000).await.unwrap();
+        assert_eq!(get_time_drift(&time_drift_db).await.unwrap(), Some((3_600_000, 1_700_000_000_000)));
+        set_time_drift(&time_drift_db, -1_000, 1_700_000_360_000).await.unwrap();
+        assert_eq!(get_time_drift(&time_drift_db).await.unwrap(), Some((-1_000, 1_700_000_360_000)));
     }
 
     #[tokio::test]
@@ -719,7 +735,7 @@ mod tests {
             record(0, 1000, "some/a", 1),
             record(1, 2000, "some/b", 2),
         ]).await.unwrap();
-        set_time_drift(&db_path, 3_600_000, 1_700_000_000_000).await.unwrap();
+        set_time_drift(&site_db_path(journal_dir, "site1"), 3_600_000, 1_700_000_000_000).await.unwrap();
 
         let mut log_records = query_log_records(
             &db_path,
@@ -727,7 +743,7 @@ mod tests {
             shvproto::DateTime::from_epoch_msec(3000),
             "",
         ).await.unwrap();
-        let (time_jump, epoch_msec) = get_time_drift(&db_path).await.unwrap().unwrap();
+        let (time_jump, epoch_msec) = get_time_drift(&site_db_path(journal_dir, "site1")).await.unwrap().unwrap();
         log_records.push(LogRecord {
             id: 0,
             timestamp: shvproto::DateTime::from_epoch_msec(epoch_msec),

--- a/src/records.rs
+++ b/src/records.rs
@@ -530,6 +530,123 @@ mod tests {
         }
     }
 
+    fn keep(id: i64, timestamp: i64, path: &str, value: impl Into<RpcValue>) -> LogRecord {
+        LogRecord {
+            id,
+            timestamp: shvproto::DateTime::from_epoch_msec(timestamp),
+            record_type: RecordType::Keep(LogEntry {
+                path: path.to_string(),
+                signal: "chng".to_string(),
+                source: "get".to_string(),
+                value: Some(value.into()),
+                access_level: AccessLevel::Read as i64,
+                user_id: None,
+                repeat: false,
+                adjusted_timestamp: None,
+                provisional: false,
+            }),
+        }
+    }
+
+    fn time_jump(id: i64, timestamp: i64, offset: i64) -> LogRecord {
+        LogRecord {
+            id,
+            timestamp: shvproto::DateTime::from_epoch_msec(timestamp),
+            record_type: RecordType::TimeJump(offset),
+        }
+    }
+
+    fn adjusted(record: &LogRecord) -> Option<i64> {
+        match &record.record_type {
+            RecordType::Normal(entry) | RecordType::Keep(entry) => entry.adjusted_timestamp,
+            RecordType::TimeJump(_) | RecordType::TimeAmbig => None,
+        }
+    }
+
+    #[test]
+    fn adjust_timestamps_without_time_jump_does_nothing() {
+        let mut records = vec![
+            record(0, 1_000, "some/a", 1),
+            record(1, 2_000, "some/b", 2),
+            record(2, 3_000, "some/c", 3),
+        ];
+        adjust_timestamps(&mut records);
+        assert_eq!(adjusted(&records[0]), None);
+        assert_eq!(adjusted(&records[1]), None);
+        assert_eq!(adjusted(&records[2]), None);
+    }
+
+    #[test]
+    fn adjust_timestamps_shifts_records_before_first_time_jump() {
+        let mut records = vec![
+            record(0, 1_000, "some/a", 1),
+            keep(1, 2_000, "some/b", 2),
+            time_jump(2, 100_000, 5_000),
+            record(3, 105_000, "some/c", 3),
+        ];
+        adjust_timestamps(&mut records);
+        assert_eq!(adjusted(&records[0]), Some(6_000));
+        assert_eq!(adjusted(&records[1]), Some(7_000));
+        assert_eq!(adjusted(&records[2]), None);
+        assert_eq!(adjusted(&records[3]), None);
+    }
+
+    #[test]
+    fn adjust_timestamps_interpolates_between_time_jumps() {
+        // Drift grows from 2_000 ms before the first jump to 1_000 ms before the second one.
+        // Between the jumps (denom = 300_000 - 1_000 - 100_000 = 199_000) records are
+        // adjusted proportionally: 1_000 * (ti - 100_000) / 199_000.
+        let mut records = vec![
+            record(0, 50_000, "some/a", 1),
+            record(1, 95_000, "some/b", 2),
+            time_jump(2, 100_000, 2_000),
+            record(3, 119_900, "some/c", 3),
+            record(4, 199_500, "some/d", 4),
+            record(5, 299_000, "some/e", 5),
+            time_jump(6, 300_000, 1_000),
+            record(7, 350_000, "some/f", 6),
+        ];
+        adjust_timestamps(&mut records);
+        assert_eq!(adjusted(&records[0]), Some(52_000));
+        assert_eq!(adjusted(&records[1]), Some(97_000));
+        assert_eq!(adjusted(&records[2]), None);
+        assert_eq!(adjusted(&records[3]), Some(120_000));
+        assert_eq!(adjusted(&records[4]), Some(200_000));
+        assert_eq!(adjusted(&records[5]), Some(300_000));
+        assert_eq!(adjusted(&records[6]), None);
+        assert_eq!(adjusted(&records[7]), None);
+    }
+
+    #[test]
+    fn adjust_timestamps_skips_provisional_records() {
+        let mut provisional = record(1, 50_000, "some/a", 1);
+        if let RecordType::Normal(entry) = &mut provisional.record_type {
+            entry.provisional = true;
+        }
+        let mut records = vec![
+            record(0, 10_000, "some/b", 2),
+            provisional,
+            time_jump(2, 100_000, 1_000),
+            record(3, 150_000, "some/c", 3),
+        ];
+        adjust_timestamps(&mut records);
+        assert_eq!(adjusted(&records[0]), Some(11_000));
+        assert_eq!(adjusted(&records[1]), None);
+        assert_eq!(adjusted(&records[3]), None);
+    }
+
+    #[test]
+    fn adjust_timestamps_with_negative_drift() {
+        let mut records = vec![
+            record(0, 50_000, "some/a", 1),
+            time_jump(1, 100_000, -1_000),
+            record(2, 150_000, "some/b", 2),
+        ];
+        adjust_timestamps(&mut records);
+        assert_eq!(adjusted(&records[0]), Some(49_000));
+        assert_eq!(adjusted(&records[2]), None);
+    }
+
     #[tokio::test]
     async fn getlog_records_aggregate() {
         let journal_dir = tempfile::TempDir::with_prefix("test-hprs-records-getlog.").unwrap();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -721,6 +721,68 @@ async fn sync_site_legacy(
     Ok(should_trim)
 }
 
+fn parse_time_drift(value: RpcValue) -> Option<(i64, i64)> {
+    let map = shvproto::rpcvalue::Map::try_from(value).ok()?;
+    let offset = i64::try_from(map.get("offset")?).ok()?;
+    let dt = i64::try_from(map.get("dt")?).ok()?;
+    Some((offset, dt))
+}
+
+async fn sync_time_drift_from_device(
+    site_path: &str,
+    site_db: &Path,
+    client_cmd_tx: &ClientCommandSender,
+    sync_logger: &impl SyncLogger,
+) -> Result<(), String>
+{
+    let remote_app_path = join_path!("shv", site_path, ".app");
+    let remote_datetime: shvproto::DateTime = RpcCall::new(&remote_app_path, "date")
+        .timeout(std::time::Duration::from_secs(5))
+        .exec(client_cmd_tx)
+        .await
+        .map_err(to_string)?;
+    let local_now = shvproto::DateTime::now();
+    let time_jump = local_now.epoch_msec() - remote_datetime.epoch_msec();
+    sync_logger.log(
+        log::Level::Info,
+        format!("Remote datetime: {remote_datetime}, time drift: {time_jump} ms")
+    );
+    records::set_time_drift(site_db, time_jump, local_now.epoch_msec()).await
+}
+
+async fn sync_time_drift(
+    site_path: &str,
+    sub_hp: &str,
+    remote_history_path: &str,
+    site_db: &Path,
+    client_cmd_tx: &ClientCommandSender,
+    sync_logger: &impl SyncLogger,
+) -> Result<(), String>
+{
+    if site_path == sub_hp {
+        // The target is a device, compute the drift from its clock.
+        sync_time_drift_from_device(site_path, site_db, client_cmd_tx, sync_logger).await
+    } else {
+        // The target is a child history provider, read its stored drift.
+        let time_drift: Option<(i64, i64)> = RpcCall::new(remote_history_path, "timeDrift")
+            .timeout(std::time::Duration::from_secs(5))
+            .exec(client_cmd_tx)
+            .await
+            .ok()
+            .and_then(parse_time_drift);
+        if let Some((offset, dt)) = time_drift {
+            sync_logger.log(
+                log::Level::Info,
+                format!("Got time drift from {remote_history_path}: offset: {offset}, dt: {dt}")
+            );
+            records::set_time_drift(site_db, offset, dt).await
+        } else {
+            // The child HP has no drift stored yet, compute it from the device clock.
+            sync_time_drift_from_device(site_path, site_db, client_cmd_tx, sync_logger).await
+        }
+    }
+}
+
 async fn sync_site_records(
     site_path: impl AsRef<str>,
     sub_hp: impl AsRef<str>,
@@ -737,6 +799,7 @@ async fn sync_site_records(
         format!("Start syncing records from {} to {}", remote_history_path, Path::new(journal_dir.as_ref()).join(site_path).to_string_lossy())
     );
 
+    let site_db = records::site_db_path(journal_dir.as_ref(), site_path);
     let mut should_trim = ShouldTrim::No;
 
     for record_name in record_names {
@@ -765,19 +828,14 @@ async fn sync_site_records(
             let Some(last_record_id) = log_records.last().map(|record| record.id) else {
                 break;
             };
-            let remote_app_path = join_path!("shv", sub_hp, ".app");
-            let remote_datetime: shvproto::DateTime = RpcCall::new(&remote_app_path, "date")
-                .timeout(std::time::Duration::from_secs(5))
-                .exec(&client_cmd_tx)
-                .await
-                .map_err(to_string)?;
-            let local_now = shvproto::DateTime::now();
-            let time_jump = local_now.epoch_msec() - remote_datetime.epoch_msec();
-            sync_logger.log(
-                log::Level::Info,
-                format!("Remote datetime: {remote_datetime}, time drift: {time_jump} ms")
-            );
-            records::set_time_drift(&db_path, time_jump, local_now.epoch_msec()).await?;
+            sync_time_drift(
+                site_path,
+                sub_hp,
+                remote_history_path,
+                &site_db,
+                &client_cmd_tx,
+                &sync_logger,
+            ).await?;
             records::insert_records(&db_path, &log_records).await?;
             should_trim = ShouldTrim::Yes;
             let next_offset = last_record_id + 1;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -723,6 +723,7 @@ async fn sync_site_legacy(
 
 async fn sync_site_records(
     site_path: impl AsRef<str>,
+    sub_hp: impl AsRef<str>,
     remote_history_path: impl AsRef<str>,
     record_names: &[String],
     client_cmd_tx: ClientCommandSender,
@@ -730,7 +731,7 @@ async fn sync_site_records(
     sync_logger: impl SyncLogger,
 ) -> Result<ShouldTrim, String>
 {
-    let (site_path, remote_history_path) = (site_path.as_ref(), remote_history_path.as_ref());
+    let (site_path, sub_hp, remote_history_path) = (site_path.as_ref(), sub_hp.as_ref(), remote_history_path.as_ref());
     sync_logger.log(
         log::Level::Info,
         format!("Start syncing records from {} to {}", remote_history_path, Path::new(journal_dir.as_ref()).join(site_path).to_string_lossy())
@@ -764,6 +765,19 @@ async fn sync_site_records(
             let Some(last_record_id) = log_records.last().map(|record| record.id) else {
                 break;
             };
+            let remote_app_path = join_path!("shv", sub_hp, ".app");
+            let remote_datetime: shvproto::DateTime = RpcCall::new(&remote_app_path, "date")
+                .timeout(std::time::Duration::from_secs(5))
+                .exec(&client_cmd_tx)
+                .await
+                .map_err(to_string)?;
+            let local_now = shvproto::DateTime::now();
+            let time_jump = local_now.epoch_msec() - remote_datetime.epoch_msec();
+            sync_logger.log(
+                log::Level::Info,
+                format!("Remote datetime: {remote_datetime}, time drift: {time_jump} ms")
+            );
+            records::set_time_drift(&db_path, time_jump, local_now.epoch_msec()).await?;
             records::insert_records(&db_path, &log_records).await?;
             should_trim = ShouldTrim::Yes;
             let next_offset = last_record_id + 1;
@@ -916,10 +930,12 @@ pub(crate) async fn sync_task(
                                 join_path!("shv", &site_info.sub_hp, ".history", site_suffix)
                             };
                             let records = records.clone();
+                            let sub_hp = site_info.sub_hp.clone();
                             let sync_task = tokio::spawn(async move {
                                     let sync_logger = SyncSiteLogger::new(&site_path, logger_tx);
                                     let sync_result = sync_site_records(
                                         site_path.clone(),
+                                        sub_hp,
                                         remote_history_path,
                                         &records,
                                         client_cmd_tx,
@@ -1002,6 +1018,7 @@ pub(crate) async fn sync_task(
                             let sync_logger = SyncSiteLogger::new(&site_path, logger_tx);
                             let sync_result = sync_site_records(
                                 site_path.clone(),
+                                &site_info.sub_hp,
                                 remote_history_path,
                                 records,
                                 client_cmd_tx,

--- a/src/sync/tests.rs
+++ b/src/sync/tests.rs
@@ -72,6 +72,7 @@ impl TestStep<SyncTaskTestState> for ExpectRecordsDb {
         assert_eq!(site, "site1");
         let db_path = records::db_path(&state.state.config.journal_dir, "site1", self.record_name);
         assert_eq!(records::fetch_records(&db_path, 0, 10).await.unwrap(), self.expected);
+        assert!(matches!(records::get_time_drift(&db_path).await.unwrap(), Some((offset, epoch_msec)) if offset > 0 && epoch_msec > 0));
         tokio::fs::remove_file(&db_path).await.ok();
         tokio::fs::remove_file(format!("{}-wal", db_path.to_string_lossy())).await.ok();
         tokio::fs::remove_file(format!("{}-shm", db_path.to_string_lossy())).await.ok();
@@ -114,6 +115,7 @@ async fn sync_task_test() -> std::result::Result<(), PrettyJoinError> {
                 Box::new(SyncCommand::SyncSite("site1".to_string())),
                 Box::new(ExpectCall("shv/site1/.history/.records/maintenance", "span", Ok(make_list![0, 1, 1].into()))),
                 Box::new(ExpectCallParam("shv/site1/.history/.records/maintenance", "fetch", make_list![0, 1].into(), Ok(vec![records_record.clone()].into()))),
+                Box::new(ExpectCall("shv/site1/.app", "date", Ok(shvproto::DateTime::now().add_hours(-1).into()))),
                 Box::new(ExpectRecordsDb {
                     record_name: "maintenance",
                     expected: vec![records_record.clone()],

--- a/src/sync/tests.rs
+++ b/src/sync/tests.rs
@@ -35,21 +35,30 @@ struct TestCase<'a> {
     expected_file_paths: Vec<(&'static str, &'a str)>,
 }
 
-struct UseRecordsSite;
+struct UseRecordsSite {
+    site_path: &'static str,
+    sub_hp: &'static str,
+}
+
+impl Default for UseRecordsSite {
+    fn default() -> Self {
+        Self { site_path: "site1", sub_hp: "site1" }
+    }
+}
 
 #[async_trait::async_trait]
 impl TestStep<SyncTaskTestState> for UseRecordsSite {
     async fn exec(&self, _client_command_reciever: &mut UnboundedReceiver<ClientCommand>, _subscriptions: &mut HashMap<String, UnboundedSender<RpcFrame>>, state: &mut SyncTaskTestState) {
         *state.state.sites_data.write().await = SitesData {
             sites_info: Arc::new(BTreeMap::from([
-                ("site1".to_string(), SiteInfo{
+                (self.site_path.to_string(), SiteInfo{
                     name: "lol".into(),
                     site_type: "Type".to_string(),
-                    sub_hp: "site1".to_owned(),
+                    sub_hp: self.sub_hp.to_owned(),
                 })
             ])),
             sub_hps: Arc::new(BTreeMap::from([
-                ("site1".to_string(), SubHpInfo::Records {
+                (self.sub_hp.to_string(), SubHpInfo::Records {
                     records: vec!["maintenance".to_string()],
                 })
             ])),
@@ -59,6 +68,7 @@ impl TestStep<SyncTaskTestState> for UseRecordsSite {
 }
 
 struct ExpectRecordsDb {
+    site: &'static str,
     record_name: &'static str,
     expected: Vec<IMap>,
 }
@@ -69,13 +79,17 @@ impl TestStep<SyncTaskTestState> for ExpectRecordsDb {
         let Some(DirtyLogCommand::Trim { site }) = state._dirtylog_cmd_rx.next().await else {
             panic!("Expected dirtylog Trim command");
         };
-        assert_eq!(site, "site1");
-        let db_path = records::db_path(&state.state.config.journal_dir, "site1", self.record_name);
+        assert_eq!(site, self.site);
+        let db_path = records::db_path(&state.state.config.journal_dir, self.site, self.record_name);
         assert_eq!(records::fetch_records(&db_path, 0, 10).await.unwrap(), self.expected);
-        assert!(matches!(records::get_time_drift(&db_path).await.unwrap(), Some((offset, epoch_msec)) if offset > 0 && epoch_msec > 0));
+        let site_db_path = records::site_db_path(&state.state.config.journal_dir, self.site);
+        assert!(matches!(records::get_time_drift(&site_db_path).await.unwrap(), Some((offset, epoch_msec)) if offset > 0 && epoch_msec > 0));
         tokio::fs::remove_file(&db_path).await.ok();
         tokio::fs::remove_file(format!("{}-wal", db_path.to_string_lossy())).await.ok();
         tokio::fs::remove_file(format!("{}-shm", db_path.to_string_lossy())).await.ok();
+        tokio::fs::remove_file(&site_db_path).await.ok();
+        tokio::fs::remove_file(format!("{}-wal", site_db_path.to_string_lossy())).await.ok();
+        tokio::fs::remove_file(format!("{}-shm", site_db_path.to_string_lossy())).await.ok();
     }
 }
 
@@ -111,12 +125,48 @@ async fn sync_task_test() -> std::result::Result<(), PrettyJoinError> {
         TestCase {
             name: "SyncSite: records fetch",
             steps: &[
-                Box::new(UseRecordsSite),
+                Box::new(UseRecordsSite::default()),
                 Box::new(SyncCommand::SyncSite("site1".to_string())),
                 Box::new(ExpectCall("shv/site1/.history/.records/maintenance", "span", Ok(make_list![0, 1, 1].into()))),
                 Box::new(ExpectCallParam("shv/site1/.history/.records/maintenance", "fetch", make_list![0, 1].into(), Ok(vec![records_record.clone()].into()))),
                 Box::new(ExpectCall("shv/site1/.app", "date", Ok(shvproto::DateTime::now().add_hours(-1).into()))),
                 Box::new(ExpectRecordsDb {
+                    site: "site1",
+                    record_name: "maintenance",
+                    expected: vec![records_record.clone()],
+                }),
+            ],
+            starting_files: vec![],
+            expected_file_paths: vec![],
+        },
+        TestCase {
+            name: "SyncSite: records fetch from sub HP reads its time drift",
+            steps: &[
+                Box::new(UseRecordsSite { site_path: "subhp1/site1", sub_hp: "subhp1" }),
+                Box::new(SyncCommand::SyncSite("subhp1/site1".to_string())),
+                Box::new(ExpectCall("shv/subhp1/.history/site1/.records/maintenance", "span", Ok(make_list![0, 1, 1].into()))),
+                Box::new(ExpectCallParam("shv/subhp1/.history/site1/.records/maintenance", "fetch", make_list![0, 1].into(), Ok(vec![records_record.clone()].into()))),
+                Box::new(ExpectCall("shv/subhp1/.history/site1", "timeDrift", Ok(make_map!("dt" => 1_700_000_000_000_i64, "offset" => 3_600_000_i64).into()))),
+                Box::new(ExpectRecordsDb {
+                    site: "subhp1/site1",
+                    record_name: "maintenance",
+                    expected: vec![records_record.clone()],
+                }),
+            ],
+            starting_files: vec![],
+            expected_file_paths: vec![],
+        },
+        TestCase {
+            name: "SyncSite: records fetch from sub HP falls back to device date when no time drift",
+            steps: &[
+                Box::new(UseRecordsSite { site_path: "subhp1/site1", sub_hp: "subhp1" }),
+                Box::new(SyncCommand::SyncSite("subhp1/site1".to_string())),
+                Box::new(ExpectCall("shv/subhp1/.history/site1/.records/maintenance", "span", Ok(make_list![0, 1, 1].into()))),
+                Box::new(ExpectCallParam("shv/subhp1/.history/site1/.records/maintenance", "fetch", make_list![0, 1].into(), Ok(vec![records_record.clone()].into()))),
+                Box::new(ExpectCall("shv/subhp1/.history/site1", "timeDrift", Ok(RpcValue::null()))),
+                Box::new(ExpectCall("shv/subhp1/site1/.app", "date", Ok(shvproto::DateTime::now().add_hours(-1).into()))),
+                Box::new(ExpectRecordsDb {
+                    site: "subhp1/site1",
                     record_name: "maintenance",
                     expected: vec![records_record.clone()],
                 }),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -52,6 +52,8 @@ const METH_FETCH: &str = "fetch";
 const META_METHOD_FETCH: MetaMethod = MetaMethod::new_static(METH_FETCH, shvrpc::metamethod::Flags::LargeResultHint, AccessLevel::Service, "[i:offset,i(0,):count]", "!historyRecords", &[], "");
 const METH_SPAN: &str = "span";
 const META_METHOD_SPAN: MetaMethod = MetaMethod::new_static(METH_SPAN, shvrpc::metamethod::Flags::IsGetter, AccessLevel::Service, "", "[i:smallest,i:biggest,i(1,):span]", &[], "");
+const METH_TIME_DRIFT: &str = "timeDrift";
+const META_METHOD_TIME_DRIFT: MetaMethod = MetaMethod::new_static(METH_TIME_DRIFT, shvrpc::metamethod::Flags::IsGetter, AccessLevel::Read, "Null", "Map|Null", &[], "");
 
 // Root node methods
 const METH_VERSION: &str = "version";
@@ -529,6 +531,19 @@ async fn getlog3_handler_rq(
     Ok(records.into())
 }
 
+async fn time_drift_handler(
+    site_path: &str,
+    app_state: Arc<State>,
+) -> Result<RpcValue, RpcError> {
+    let db_path = records::site_db_path(&app_state.config.journal_dir, site_path);
+    let drift = records::get_time_drift(db_path)
+        .await
+        .map_err(|err| RpcError::new(RpcErrorCode::MethodCallException, format!("Cannot get time drift: {err}")))?;
+    Ok(drift.map_or_else(RpcValue::null, |(offset, epoch_msec)|
+        shvproto::make_map!("dt" => epoch_msec, "offset" => offset).into()
+    ))
+}
+
 fn records_site_for_path(sites_data: &SitesData, path: &str) -> Option<(String, String, Vec<String>)> {
     let (site_path, path_prefix) = find_longest_path_prefix(sites_data.sites_info.as_ref(), path)?;
     let site_info = sites_data.sites_info.get(site_path)?;
@@ -839,7 +854,7 @@ pub(crate) async fn request_handler(
                     return err_unresolved_request();
                 }
                 let methods = if records_site.is_some() {
-                    const METHODS: &[MetaMethod] = &[META_METHOD_GET_LOG];
+                    const METHODS: &[MetaMethod] = &[META_METHOD_GET_LOG, META_METHOD_TIME_DRIFT];
                     METHODS
                 } else {
                     const METHODS: &[MetaMethod] = &[];
@@ -873,6 +888,7 @@ pub(crate) async fn request_handler(
                 }
                 Method::Other(m) => match m.method() {
                     METH_GET_LOG if records_site.is_some() => m.resolve(methods, async move || { getlog3_handler_rq(&path, &param, app_state).await }),
+                    METH_TIME_DRIFT if records_site.is_some() => m.resolve(methods, async move || { time_drift_handler(&path, app_state).await }),
                     _ => err_unresolved_request(),
                 },
             }


### PR DESCRIPTION
Interpolates timestamps across time jump records.

Timestamps before the first time jump are just shifted.

Timestamps after the last time jump are not adjusted, because provisional entries have timestamps from the HP, which is believed to have a correct clock and those entries will be eventually replaced by next sync.